### PR TITLE
Fix width of editor if field error exists

### DIFF
--- a/app/assets/stylesheets/activeadmin/_froala_editor_input.sass
+++ b/app/assets/stylesheets/activeadmin/_froala_editor_input.sass
@@ -4,7 +4,7 @@
 body.active_admin form .froala_editor
   i.fa
     text-shadow: none
-  >.fr-box
+  .fr-box
     display: inline-block
     width: calc(80% - 22px)
   .fr-wrapper


### PR DESCRIPTION
Hi Mattia Roccoberton!

You have created good wysiwyg editor.
I am use it at work and I found css bug. When I get field error this editor increase width. I've attached screenshot for clarity.

![froala-editor](https://user-images.githubusercontent.com/3122276/54710647-967a0200-4b61-11e9-8fd5-f36b93eb82d2.png)

I use versions:
- rails 5.2.2
- activeadmin 1.4.3
- activeadmin_froala_editor 0.1.3

I think my PR will fix this bug.
Thanks!